### PR TITLE
Add async support to GEPA

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -1,5 +1,6 @@
 import csv
 import importlib
+import inspect
 import json
 import logging
 import types
@@ -169,7 +170,11 @@ class Evaluate:
 
         def process_item(example):
             prediction = program(**example.inputs())
-            score = metric(example, prediction)
+            if inspect.iscoroutinefunction(metric):
+                from dspy.utils.syncify import run_async
+                score = run_async(metric(example, prediction))
+            else:
+                score = metric(example, prediction)
             return prediction, score
 
         results = executor.execute(process_item, devset)

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -6,6 +6,8 @@ import logging
 import types
 from typing import TYPE_CHECKING, Any, Callable
 
+from dspy.utils.syncify import run_async
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -171,7 +173,6 @@ class Evaluate:
         def process_item(example):
             prediction = program(**example.inputs())
             if inspect.iscoroutinefunction(metric):
-                from dspy.utils.syncify import run_async
                 score = run_async(metric(example, prediction))
             else:
                 score = metric(example, prediction)

--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -10,6 +10,7 @@ from dspy.primitives.example import Example
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
 from dspy.utils.exceptions import AdapterParseError
+from dspy.utils.syncify import run_async
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,6 @@ def bootstrap_trace_data(
         if not metric:
             return True
         if inspect.iscoroutinefunction(metric):
-            from dspy.utils.syncify import run_async
             return run_async(metric(example, prediction, trace))
         return metric(example, prediction, trace)
 

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -514,13 +514,23 @@ class GEPA(Teleprompter):
                 captured_trace: "DSPyTrace",
             ) -> "ScoreWithFeedback":
                 trace_for_pred = [(predictor, predictor_inputs, predictor_output)]
-                o = self.metric_fn(
-                    module_inputs,
-                    module_outputs,
-                    captured_trace,
-                    pred_name,
-                    trace_for_pred,
-                )
+                if inspect.iscoroutinefunction(self.metric_fn):
+                    from dspy.utils.syncify import run_async
+                    o = run_async(self.metric_fn(
+                        module_inputs,
+                        module_outputs,
+                        captured_trace,
+                        pred_name,
+                        trace_for_pred,
+                    ))
+                else:
+                    o = self.metric_fn(
+                        module_inputs,
+                        module_outputs,
+                        captured_trace,
+                        pred_name,
+                        trace_for_pred,
+                    )
                 if hasattr(o, "feedback"):
                     if o["feedback"] is None:
                         o["feedback"] = f"This trajectory got a score of {o['score']}."

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -13,6 +13,7 @@ from dspy.primitives import Example, Module, Prediction
 from dspy.teleprompt.gepa.gepa_utils import DspyAdapter, DSPyTrace, PredictorFeedbackFn, ScoreWithFeedback
 from dspy.teleprompt.teleprompt import Teleprompter
 from dspy.utils.annotation import experimental
+from dspy.utils.syncify import run_async
 
 logger = logging.getLogger(__name__)
 
@@ -515,7 +516,6 @@ class GEPA(Teleprompter):
             ) -> "ScoreWithFeedback":
                 trace_for_pred = [(predictor, predictor_inputs, predictor_output)]
                 if inspect.iscoroutinefunction(self.metric_fn):
-                    from dspy.utils.syncify import run_async
                     o = run_async(self.metric_fn(
                         module_inputs,
                         module_outputs,

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -396,3 +396,31 @@ def test_evaluate_save_as_csv_with_history():
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
+
+async def async_metric(example, prediction, trace=None):
+    """Async metric for testing."""
+    import asyncio
+    await asyncio.sleep(0.001)
+    return example.answer == prediction.answer
+
+
+def test_evaluate_with_async_metric():
+    """Test that Evaluate can work with async metrics."""
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "What is 1+1?": {"answer": "2"},
+                "What is 2+2?": {"answer": "4"},
+            }
+        )
+    )
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    program = Predict("question -> answer")
+    ev = Evaluate(
+        devset=devset,
+        metric=async_metric,
+        display_progress=False,
+    )
+    result = ev(program)
+    assert result.score == 100.0
+

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -1,7 +1,12 @@
+import asyncio
+import csv
 import json
+import os
 import signal
 import tempfile
 import threading
+import time
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +17,11 @@ from dspy.evaluate.metrics import answer_exact_match
 from dspy.predict import Predict
 from dspy.utils.callback import BaseCallback
 from dspy.utils.dummies import DummyLM
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 
 def new_example(question, answer):
@@ -58,7 +68,6 @@ def test_evaluate_call():
 
 @pytest.mark.extra
 def test_construct_result_df():
-    import pandas as pd
     devset = [
         new_example("What is 1+1?", "2"),
         new_example("What is 2+2?", "4"),
@@ -106,8 +115,6 @@ def test_multi_thread_evaluate_call_cancelled(monkeypatch):
     # slow LM that sleeps for 1 second before returning the answer
     class SlowLM(DummyLM):
         def __call__(self, *args, **kwargs):
-            import time
-
             time.sleep(1)
             return super().__call__(*args, **kwargs)
 
@@ -119,11 +126,7 @@ def test_multi_thread_evaluate_call_cancelled(monkeypatch):
 
     # spawn a thread that will sleep for .1 seconds then send a KeyboardInterrupt
     def sleep_then_interrupt():
-        import time
-
         time.sleep(0.1)
-        import os
-
         os.kill(os.getpid(), signal.SIGINT)
 
     input_thread = threading.Thread(target=sleep_then_interrupt)
@@ -335,7 +338,6 @@ def test_evaluate_save_as_json_with_history():
         assert data[1]["history"]["messages"][1] == {"question": "Previous Q3", "answer": "Previous A3"}
 
     finally:
-        import os
         if os.path.exists(temp_json):
             os.unlink(temp_json)
 
@@ -381,7 +383,6 @@ def test_evaluate_save_as_csv_with_history():
         assert result.score == 100.0
 
         # Verify CSV file was created
-        import csv
         with open(temp_csv) as f:
             reader = csv.DictReader(f)
             rows = list(reader)
@@ -392,14 +393,12 @@ def test_evaluate_save_as_csv_with_history():
         assert "messages" in rows[0]["history"]
 
     finally:
-        import os
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
 
-async def async_metric(example, prediction, trace=None):
+async def async_metric(example: dspy.Example, prediction: dspy.Prediction, trace: Any = None) -> bool:
     """Async metric for testing."""
-    import asyncio
     await asyncio.sleep(0.001)
     return example.answer == prediction.answer
 

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import threading
 from typing import Any
@@ -523,9 +524,14 @@ def test_alternating_half_component_selector():
             assert "classifier" not in selection["selected"], f"Odd iteration {selection['iteration']} should not include classifier"
 
 
-async def async_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
+async def async_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace: Any = None,
+    pred_name: str | None = None,
+    pred_trace: Any = None,
+) -> dspy.Prediction:
     """Async version of simple_metric for testing async support."""
-    import asyncio
     await asyncio.sleep(0.001)
     return dspy.Prediction(score=example.output == prediction.output, feedback="Async feedback")
 


### PR DESCRIPTION
This patch adds support for passing async metric functions to GEPA. It's implemented by adding checks for async at all locations (3 in total) where the metric function is invoked and calling `run_async` from utilities to handle the actual invocation. 

Fixes: https://github.com/swe-productivity/dspy/issues/2