### PR TITLE
Add pydantic field descriptions in prompts

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, Union, get_args, get_origin
 
 import json_repair
 import pydantic
-from pydantic import TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.types.base_type import Type as DspyType
@@ -211,7 +211,7 @@ def get_annotation_name(annotation):
         return f"{get_annotation_name(origin)}[{args_str}]"
 
 
-def is_pydantic_model(annotation: Any) -> bool:
+def _is_pydantic_model(annotation: Any) -> bool:
     """Check if a type annotation is or contains a Pydantic BaseModel.
 
     Handles:
@@ -226,8 +226,6 @@ def is_pydantic_model(annotation: Any) -> bool:
         True if annotation is or contains a Pydantic BaseModel
     """
     try:
-        from pydantic import BaseModel
-
         # Direct check
         if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
             return True
@@ -236,12 +234,12 @@ def is_pydantic_model(annotation: Any) -> bool:
         origin = get_origin(annotation)
         if origin is Union or (hasattr(types, 'UnionType') and origin is types.UnionType):
             args = get_args(annotation)
-            return any(is_pydantic_model(arg) for arg in args if arg is not type(None))
+            return any(_is_pydantic_model(arg) for arg in args if arg is not type(None))
 
         # Handle generic types (List[Model], Dict[str, Model], etc.)
         if origin is not None:
             args = get_args(annotation)
-            return any(is_pydantic_model(arg) for arg in args)
+            return any(_is_pydantic_model(arg) for arg in args)
 
     except (TypeError, ImportError):
         pass
@@ -251,30 +249,46 @@ def is_pydantic_model(annotation: Any) -> bool:
 
 def extract_pydantic_field_descriptions(
     model_class: type,
-    max_depth: int = 3,
-    _visited: set | None = None,
+    max_depth: int | None = None,
+    visited: set | None = None,
     _indent_level: int = 1,
 ) -> str:
     """Extract field descriptions from a Pydantic model recursively.
 
     Args:
         model_class: Pydantic BaseModel class
-        max_depth: Maximum recursion depth
-        _visited: Internal use - tracks visited models
+        max_depth: Maximum recursion depth. None means no limit (default).
+                   The visited set prevents infinite recursion from circular references.
+        visited: Internal use - tracks visited models to prevent circular references
         _indent_level: Internal use - current indentation level
 
     Returns:
         Formatted string with field descriptions
+
+    Example:
+        >>> class Address(BaseModel):
+        ...     street: str = Field(description="Street address")
+        ...     city: str = Field(description="City name")
+        ...
+        >>> class Person(BaseModel):
+        ...     name: str = Field(description="Full name of the person")
+        ...     age: int = Field(description="Age in years")
+        ...     address: Address = Field(description="Home address")
+        ...
+        >>> print(extract_pydantic_field_descriptions(Person))
+            - name (str): Full name of the person
+            - age (int): Age in years
+            - address (Address): Home address
+                - street (str): Street address
+                - city (str): City name
     """
-    from pydantic import BaseModel
+    if visited is None:
+        visited = set()
 
-    if _visited is None:
-        _visited = set()
-
-    if max_depth <= 0 or model_class in _visited:
+    if model_class in visited or (max_depth is not None and max_depth <= 0):
         return ""
 
-    _visited = _visited | {model_class}
+    visited = visited | {model_class}
     indent = "    " * _indent_level
     lines = []
 
@@ -287,10 +301,11 @@ def extract_pydantic_field_descriptions(
 
         lines.append(line)
 
-        if is_pydantic_model(field_info.annotation):
+        if _is_pydantic_model(field_info.annotation):
             for nested_model in _extract_models_from_annotation(field_info.annotation):
+                next_depth = None if max_depth is None else max_depth - 1
                 nested = extract_pydantic_field_descriptions(
-                    nested_model, max_depth - 1, _visited, _indent_level + 1
+                    nested_model, next_depth, visited, _indent_level + 1
                 )
                 if nested:
                     lines.append(nested)
@@ -300,14 +315,11 @@ def extract_pydantic_field_descriptions(
 
 def _extract_models_from_annotation(annotation: Any) -> list[type]:
     """Extract Pydantic model classes from a type annotation."""
-    from pydantic import BaseModel
-
     if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
         return [annotation]
 
     models = []
-    origin = get_origin(annotation)
-    if origin is not None:
+    if (origin := get_origin(annotation)) is not None:
         for arg in get_args(annotation):
             if arg is not type(None):
                 models.extend(_extract_models_from_annotation(arg))
@@ -322,9 +334,9 @@ def get_field_description_string(fields: dict) -> str:
         field_message += f" ({get_annotation_name(v.annotation)})"
         desc = v.json_schema_extra["desc"] if v.json_schema_extra["desc"] != f"${{{k}}}" else ""
 
-        if is_pydantic_model(v.annotation):
+        if _is_pydantic_model(v.annotation):
             for model_class in _extract_models_from_annotation(v.annotation):
-                nested_desc = extract_pydantic_field_descriptions(model_class, max_depth=3)
+                nested_desc = extract_pydantic_field_descriptions(model_class)
                 if nested_desc:
                     desc += f"\n    Fields:\n{nested_desc}"
 

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -173,14 +173,18 @@ def test_json_adapter_on_pydantic_model():
         assert content is not None
 
         # Assert that system prompt includes correct input field descriptions
-        expected_input_fields = (
-            "1. `user` (User): The user who asks the question\n2. `question` (str): Question the user asks\n"
-        )
-        assert expected_input_fields in content
+        assert "1. `user` (User): The user who asks the question" in content
+        assert "2. `question` (str): Question the user asks" in content
+        # Assert nested User fields are included
+        assert "- id (int)" in content
+        assert "- name (str)" in content
+        assert "- email (str)" in content
 
         # Assert that system prompt includes correct output field description
-        expected_output_fields = "1. `answer` (Answer): Answer to this question\n"
-        assert expected_output_fields in content
+        assert "1. `answer` (Answer): Answer to this question" in content
+        # Assert nested Answer fields are included
+        assert "- analysis (str)" in content
+        assert "- result (str)" in content
 
         # Assert that system prompt includes input formatting structure
         expected_input_structure = "[[ ## user ## ]]\n{user}\n\n[[ ## question ## ]]\n{question}\n\n"
@@ -584,14 +588,18 @@ async def test_json_adapter_on_pydantic_model_async():
         assert content is not None
 
         # Assert that system prompt includes correct input field descriptions
-        expected_input_fields = (
-            "1. `user` (User): The user who asks the question\n2. `question` (str): Question the user asks\n"
-        )
-        assert expected_input_fields in content
+        assert "1. `user` (User): The user who asks the question" in content
+        assert "2. `question` (str): Question the user asks" in content
+        # Assert nested User fields are included
+        assert "- id (int)" in content
+        assert "- name (str)" in content
+        assert "- email (str)" in content
 
         # Assert that system prompt includes correct output field description
-        expected_output_fields = "1. `answer` (Answer): Answer to this question\n"
-        assert expected_output_fields in content
+        assert "1. `answer` (Answer): Answer to this question" in content
+        # Assert nested Answer fields are included
+        assert "- analysis (str)" in content
+        assert "- result (str)" in content
 
         # Assert that system prompt includes input formatting structure
         expected_input_structure = "[[ ## user ## ]]\n{user}\n\n[[ ## question ## ]]\n{question}\n\n"

--- a/tests/adapters/test_pydantic_field_descriptions.py
+++ b/tests/adapters/test_pydantic_field_descriptions.py
@@ -1,0 +1,320 @@
+"""Tests for Pydantic field description extraction in adapters."""
+
+import pytest
+from pydantic import BaseModel, Field
+from typing import Optional, Union, List, Dict
+
+import dspy
+from dspy.adapters.chat_adapter import ChatAdapter
+from dspy.adapters.utils import (
+    is_pydantic_model,
+    extract_pydantic_field_descriptions,
+    get_field_description_string,
+)
+
+
+class SimpleModel(BaseModel):
+    """A simple Pydantic model for testing."""
+
+    field: str
+
+
+class AnotherModel(BaseModel):
+    """Another Pydantic model for testing."""
+
+    value: int
+
+
+def test_is_pydantic_model_with_direct_model():
+    """Test that is_pydantic_model returns True for a direct Pydantic model."""
+    assert is_pydantic_model(SimpleModel) is True
+
+
+def test_is_pydantic_model_with_primitive_types():
+    """Test that is_pydantic_model returns False for primitive types."""
+    assert is_pydantic_model(str) is False
+    assert is_pydantic_model(int) is False
+    assert is_pydantic_model(float) is False
+    assert is_pydantic_model(bool) is False
+    assert is_pydantic_model(list) is False
+    assert is_pydantic_model(dict) is False
+
+
+def test_is_pydantic_model_with_optional_model():
+    """Test that is_pydantic_model returns True for Optional[Model]."""
+    assert is_pydantic_model(Optional[SimpleModel]) is True
+
+
+def test_is_pydantic_model_with_optional_primitive():
+    """Test that is_pydantic_model returns False for Optional[primitive]."""
+    assert is_pydantic_model(Optional[str]) is False
+    assert is_pydantic_model(Optional[int]) is False
+
+
+def test_is_pydantic_model_with_union_containing_model():
+    """Test that is_pydantic_model returns True for Union containing a model."""
+    assert is_pydantic_model(Union[SimpleModel, str]) is True
+    assert is_pydantic_model(Union[str, SimpleModel]) is True
+    assert is_pydantic_model(Union[SimpleModel, AnotherModel]) is True
+
+
+def test_is_pydantic_model_with_union_without_model():
+    """Test that is_pydantic_model returns False for Union without models."""
+    assert is_pydantic_model(Union[str, int]) is False
+    assert is_pydantic_model(Union[str, int, float]) is False
+
+
+def test_is_pydantic_model_with_list_of_models():
+    """Test that is_pydantic_model returns True for List[Model]."""
+    assert is_pydantic_model(List[SimpleModel]) is True
+
+
+def test_is_pydantic_model_with_list_of_primitives():
+    """Test that is_pydantic_model returns False for List[primitive]."""
+    assert is_pydantic_model(List[str]) is False
+    assert is_pydantic_model(List[int]) is False
+
+
+def test_is_pydantic_model_with_dict_of_models():
+    """Test that is_pydantic_model returns True for Dict with model values."""
+    assert is_pydantic_model(Dict[str, SimpleModel]) is True
+
+
+def test_is_pydantic_model_with_dict_of_primitives():
+    """Test that is_pydantic_model returns False for Dict with primitive values."""
+    assert is_pydantic_model(Dict[str, str]) is False
+    assert is_pydantic_model(Dict[str, int]) is False
+
+
+def test_is_pydantic_model_with_nested_generics():
+    """Test that is_pydantic_model handles nested generic types."""
+    assert is_pydantic_model(List[Optional[SimpleModel]]) is True
+    assert is_pydantic_model(Dict[str, Optional[SimpleModel]]) is True
+    assert is_pydantic_model(Optional[List[SimpleModel]]) is True
+
+
+def test_extract_simple_model_descriptions():
+    """Test extracting descriptions from a simple Pydantic model."""
+
+    class SearchQuery(BaseModel):
+        term: str = Field(description="search term to extract topics from")
+        grade: int = Field(description="grade level of the audience")
+        country: str = Field(description="country of the audience")
+
+    result = extract_pydantic_field_descriptions(SearchQuery)
+
+    assert "term" in result
+    assert "search term to extract topics from" in result
+    assert "grade" in result
+    assert "grade level of the audience" in result
+    assert "country" in result
+    assert "country of the audience" in result
+
+
+def test_extract_model_without_descriptions():
+    """Test extracting from a model without field descriptions."""
+
+    class BasicModel(BaseModel):
+        name: str
+        age: int
+
+    result = extract_pydantic_field_descriptions(BasicModel)
+
+    assert "name (str)" in result
+    assert "age (int)" in result
+
+
+def test_extract_nested_model_descriptions():
+    """Test extracting descriptions from nested Pydantic models."""
+
+    class Address(BaseModel):
+        street: str = Field(description="Street name")
+        city: str = Field(description="City name")
+
+    class Person(BaseModel):
+        name: str = Field(description="Person's name")
+        address: Address = Field(description="Person's address")
+
+    result = extract_pydantic_field_descriptions(Person)
+
+    assert "name" in result
+    assert "Person's name" in result
+    assert "address" in result
+    assert "street" in result
+    assert "Street name" in result
+    assert "city" in result
+    assert "City name" in result
+
+
+def test_extract_with_circular_reference():
+    """Test that circular references don't cause infinite loops."""
+
+    class Node(BaseModel):
+        value: int = Field(description="Node value")
+        next: Optional["Node"] = Field(default=None, description="Next node")
+
+    result = extract_pydantic_field_descriptions(Node, max_depth=3)
+
+    assert "value" in result
+    assert "Node value" in result
+    assert "next" in result
+
+
+def test_extract_respects_max_depth():
+    """Test that max_depth parameter limits recursion."""
+
+    class Level3(BaseModel):
+        field3: str = Field(description="Level 3 field")
+
+    class Level2(BaseModel):
+        field2: str = Field(description="Level 2 field")
+        nested: Level3
+
+    class Level1(BaseModel):
+        field1: str = Field(description="Level 1 field")
+        nested: Level2
+
+    result = extract_pydantic_field_descriptions(Level1, max_depth=2)
+
+    assert "field1" in result
+    assert "field2" in result
+    assert "field3" not in result
+
+
+def test_extract_with_optional_model():
+    """Test extracting from Optional[Model] field."""
+
+    class Inner(BaseModel):
+        value: str = Field(description="Inner value")
+
+    class Outer(BaseModel):
+        data: Optional[Inner] = Field(description="Optional inner data")
+
+    result = extract_pydantic_field_descriptions(Outer)
+
+    assert "data" in result
+    assert "value" in result
+    assert "Inner value" in result
+
+
+def test_extract_with_list_of_models():
+    """Test extracting from List[Model] field."""
+
+    class Item(BaseModel):
+        name: str = Field(description="Item name")
+
+    class Container(BaseModel):
+        items: List[Item] = Field(description="List of items")
+
+    result = extract_pydantic_field_descriptions(Container)
+
+    assert "items" in result
+    assert "name" in result
+    assert "Item name" in result
+
+
+def test_get_field_description_string_with_pydantic_model():
+    """Test that get_field_description_string includes nested Pydantic field descriptions."""
+
+    class SearchQuery(BaseModel):
+        term: str = Field(description="search term")
+        grade: int = Field(description="grade level")
+
+    class TestSignature(dspy.Signature):
+        """Test signature"""
+
+        query: SearchQuery = dspy.InputField(desc="The search query")
+        result: str = dspy.OutputField()
+
+    desc = get_field_description_string(TestSignature.input_fields)
+
+    assert "query" in desc
+    assert "SearchQuery" in desc
+    assert "term" in desc
+    assert "search term" in desc
+    assert "grade" in desc
+    assert "grade level" in desc
+
+
+def test_chat_adapter_includes_pydantic_descriptions():
+    """Test that ChatAdapter includes nested Pydantic descriptions in formatted prompts."""
+
+    class Query(BaseModel):
+        term: str = Field(description="search term")
+        grade: int = Field(description="grade level")
+
+    class TopicExtraction(dspy.Signature):
+        """Extract topics from a search term"""
+
+        query: Query = dspy.InputField()
+        topics: List[str] = dspy.OutputField(desc="list of topics")
+
+    adapter = ChatAdapter()
+    field_desc = adapter.format_field_description(TopicExtraction)
+
+    assert "query" in field_desc
+    assert "Query" in field_desc
+    assert "term" in field_desc
+    assert "search term" in field_desc
+    assert "grade" in field_desc
+    assert "grade level" in field_desc
+
+
+def test_end_to_end_with_nested_models():
+    """Test end-to-end with nested Pydantic models in signature."""
+
+    class Address(BaseModel):
+        street: str = Field(description="Street name")
+        city: str = Field(description="City name")
+
+    class Person(BaseModel):
+        name: str = Field(description="Person's full name")
+        age: int = Field(description="Person's age")
+        address: Address = Field(description="Person's address")
+
+    class PersonSignature(dspy.Signature):
+        """Process person information"""
+
+        person: Person = dspy.InputField()
+        summary: str = dspy.OutputField()
+
+    adapter = ChatAdapter()
+    field_desc = adapter.format_field_description(PersonSignature)
+
+    assert "person" in field_desc
+    assert "name" in field_desc
+    assert "Person's full name" in field_desc
+    assert "age" in field_desc
+    assert "Person's age" in field_desc
+    assert "address" in field_desc
+    assert "Person's address" in field_desc
+    assert "street" in field_desc
+    assert "Street name" in field_desc
+    assert "city" in field_desc
+    assert "City name" in field_desc
+
+
+def test_original_use_case_from_issue():
+    """Test the exact use case from the feature request."""
+
+    class SearchQuery(BaseModel):
+        term: str = Field(description="search term to extract topics from")
+        grade: int = Field(description="grade level of the audience")
+        country: str = Field(description="country of the audience")
+
+    class TopicExtraction(dspy.Signature):
+        """Extract topics from a search term"""
+
+        search_query: SearchQuery = dspy.InputField()
+        topics: List[str] = dspy.OutputField(desc="list of topics")
+
+    adapter = ChatAdapter()
+    field_desc = adapter.format_field_description(TopicExtraction)
+
+    assert "search_query" in field_desc
+    assert "term" in field_desc
+    assert "search term to extract topics from" in field_desc
+    assert "grade" in field_desc
+    assert "grade level of the audience" in field_desc
+    assert "country" in field_desc
+    assert "country of the audience" in field_desc

--- a/tests/adapters/test_pydantic_field_descriptions.py
+++ b/tests/adapters/test_pydantic_field_descriptions.py
@@ -7,7 +7,7 @@ from typing import Optional, Union, List, Dict
 import dspy
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.utils import (
-    is_pydantic_model,
+    __is_pydantic_model,
     extract_pydantic_field_descriptions,
     get_field_description_string,
 )
@@ -25,77 +25,64 @@ class AnotherModel(BaseModel):
     value: int
 
 
-def test_is_pydantic_model_with_direct_model():
-    """Test that is_pydantic_model returns True for a direct Pydantic model."""
-    assert is_pydantic_model(SimpleModel) is True
+def test__is_pydantic_model_with_direct_model():
+    assert _is_pydantic_model(SimpleModel) is True
 
 
-def test_is_pydantic_model_with_primitive_types():
-    """Test that is_pydantic_model returns False for primitive types."""
-    assert is_pydantic_model(str) is False
-    assert is_pydantic_model(int) is False
-    assert is_pydantic_model(float) is False
-    assert is_pydantic_model(bool) is False
-    assert is_pydantic_model(list) is False
-    assert is_pydantic_model(dict) is False
+def test__is_pydantic_model_with_primitive_types():
+    assert _is_pydantic_model(str) is False
+    assert _is_pydantic_model(int) is False
+    assert _is_pydantic_model(float) is False
+    assert _is_pydantic_model(bool) is False
+    assert _is_pydantic_model(list) is False
+    assert _is_pydantic_model(dict) is False
 
 
-def test_is_pydantic_model_with_optional_model():
-    """Test that is_pydantic_model returns True for Optional[Model]."""
-    assert is_pydantic_model(Optional[SimpleModel]) is True
+def test__is_pydantic_model_with_optional_model():
+    assert _is_pydantic_model(Optional[SimpleModel]) is True
 
 
-def test_is_pydantic_model_with_optional_primitive():
-    """Test that is_pydantic_model returns False for Optional[primitive]."""
-    assert is_pydantic_model(Optional[str]) is False
-    assert is_pydantic_model(Optional[int]) is False
+def test__is_pydantic_model_with_optional_primitive():
+    assert _is_pydantic_model(Optional[str]) is False
+    assert _is_pydantic_model(Optional[int]) is False
 
 
-def test_is_pydantic_model_with_union_containing_model():
-    """Test that is_pydantic_model returns True for Union containing a model."""
-    assert is_pydantic_model(Union[SimpleModel, str]) is True
-    assert is_pydantic_model(Union[str, SimpleModel]) is True
-    assert is_pydantic_model(Union[SimpleModel, AnotherModel]) is True
+def test__is_pydantic_model_with_union_containing_model():
+    assert _is_pydantic_model(Union[SimpleModel, str]) is True
+    assert _is_pydantic_model(Union[str, SimpleModel]) is True
+    assert _is_pydantic_model(Union[SimpleModel, AnotherModel]) is True
 
 
-def test_is_pydantic_model_with_union_without_model():
-    """Test that is_pydantic_model returns False for Union without models."""
-    assert is_pydantic_model(Union[str, int]) is False
-    assert is_pydantic_model(Union[str, int, float]) is False
+def test__is_pydantic_model_with_union_without_model():
+    assert _is_pydantic_model(Union[str, int]) is False
+    assert _is_pydantic_model(Union[str, int, float]) is False
 
 
-def test_is_pydantic_model_with_list_of_models():
-    """Test that is_pydantic_model returns True for List[Model]."""
-    assert is_pydantic_model(List[SimpleModel]) is True
+def test__is_pydantic_model_with_list_of_models():
+    assert _is_pydantic_model(List[SimpleModel]) is True
 
 
-def test_is_pydantic_model_with_list_of_primitives():
-    """Test that is_pydantic_model returns False for List[primitive]."""
-    assert is_pydantic_model(List[str]) is False
-    assert is_pydantic_model(List[int]) is False
+def test__is_pydantic_model_with_list_of_primitives():
+    assert _is_pydantic_model(List[str]) is False
+    assert _is_pydantic_model(List[int]) is False
 
 
-def test_is_pydantic_model_with_dict_of_models():
-    """Test that is_pydantic_model returns True for Dict with model values."""
-    assert is_pydantic_model(Dict[str, SimpleModel]) is True
+def test__is_pydantic_model_with_dict_of_models():
+    assert _is_pydantic_model(Dict[str, SimpleModel]) is True
 
 
-def test_is_pydantic_model_with_dict_of_primitives():
-    """Test that is_pydantic_model returns False for Dict with primitive values."""
-    assert is_pydantic_model(Dict[str, str]) is False
-    assert is_pydantic_model(Dict[str, int]) is False
+def test__is_pydantic_model_with_dict_of_primitives():
+    assert _is_pydantic_model(Dict[str, str]) is False
+    assert _is_pydantic_model(Dict[str, int]) is False
 
 
-def test_is_pydantic_model_with_nested_generics():
-    """Test that is_pydantic_model handles nested generic types."""
-    assert is_pydantic_model(List[Optional[SimpleModel]]) is True
-    assert is_pydantic_model(Dict[str, Optional[SimpleModel]]) is True
-    assert is_pydantic_model(Optional[List[SimpleModel]]) is True
+def test__is_pydantic_model_with_nested_generics():
+    assert _is_pydantic_model(List[Optional[SimpleModel]]) is True
+    assert _is_pydantic_model(Dict[str, Optional[SimpleModel]]) is True
+    assert _is_pydantic_model(Optional[List[SimpleModel]]) is True
 
 
 def test_extract_simple_model_descriptions():
-    """Test extracting descriptions from a simple Pydantic model."""
-
     class SearchQuery(BaseModel):
         term: str = Field(description="search term to extract topics from")
         grade: int = Field(description="grade level of the audience")
@@ -112,8 +99,6 @@ def test_extract_simple_model_descriptions():
 
 
 def test_extract_model_without_descriptions():
-    """Test extracting from a model without field descriptions."""
-
     class BasicModel(BaseModel):
         name: str
         age: int
@@ -125,8 +110,6 @@ def test_extract_model_without_descriptions():
 
 
 def test_extract_nested_model_descriptions():
-    """Test extracting descriptions from nested Pydantic models."""
-
     class Address(BaseModel):
         street: str = Field(description="Street name")
         city: str = Field(description="City name")
@@ -182,8 +165,6 @@ def test_extract_respects_max_depth():
 
 
 def test_extract_with_optional_model():
-    """Test extracting from Optional[Model] field."""
-
     class Inner(BaseModel):
         value: str = Field(description="Inner value")
 
@@ -198,8 +179,6 @@ def test_extract_with_optional_model():
 
 
 def test_extract_with_list_of_models():
-    """Test extracting from List[Model] field."""
-
     class Item(BaseModel):
         name: str = Field(description="Item name")
 


### PR DESCRIPTION
Fixes: https://github.com/swe-productivity/dspy/issues/5

In case of a pydantic description such as this:
```
class Address(BaseModel):
      street: str = Field(description="Street address")
      city: str = Field(description="City name")
      zip_code: str = Field(description="ZIP or postal code")

  class Person(BaseModel):
      name: str = Field(description="Full name of the person")
      age: int = Field(description="Age in years")
      email: str = Field(description="Email address")
      address: Address = Field(description="Home address")
```
The LLM would see a description like this:
```
1. `person` (Person): Person to process
      Fields:
      - name (str): Full name of the person
      - age (int): Age in years
      - email (str): Email address
      - address (Address): Home address
          - street (str): Street address
          - city (str): City name
          - zip_code (str): ZIP or postal code
```
Earlier it could see just `person`, not the nested fields that it contains.