### PR TITLE
Added support for launch_kwargs to pass through SGLang Server for local models

### DIFF
--- a/dspy/clients/lm_local.py
+++ b/dspy/clients/lm_local.py
@@ -67,6 +67,15 @@ class LocalProvider(Provider):
             "0.0.0.0",
         ]
 
+        # Allow user to supply extra CLI arguments, e.g. CUDA graph flags
+        extra_args = launch_kwargs.get("extra_args")
+        if extra_args:
+            if isinstance(extra_args, str):
+                command.extend(extra_args.split())
+            else:
+                command.extend(extra_args)
+
+
         # We will manually stream & capture logs.
         process = subprocess.Popen(
             command,

--- a/dspy/clients/lm_local.py
+++ b/dspy/clients/lm_local.py
@@ -68,12 +68,10 @@ class LocalProvider(Provider):
         ]
 
         # Allow user to supply extra CLI arguments, e.g. CUDA graph flags
-        extra_args = launch_kwargs.get("extra_args")
-        if extra_args:
-            if isinstance(extra_args, str):
-                command.extend(extra_args.split())
-            else:
-                command.extend(extra_args)
+        if extra_args := launch_kwargs.get("extra_args"):
+            if not isinstance(extra_args, list):
+                raise ValueError("extra_args must be a list")
+            command.extend(extra_args)
 
 
         # We will manually stream & capture logs.

--- a/tests/clients/test_lm_local.py
+++ b/tests/clients/test_lm_local.py
@@ -18,11 +18,13 @@ def test_command_with_spaces_in_path(mock_wait, mock_port, mock_popen, mock_thre
 
     lm = mock.Mock(spec=[])
     lm.model = "/path/to/my models/llama"
-    lm.launch_kwargs = {}
+    lm.launch_kwargs = {
+        "extra_args": "--cuda-graph-max-bs 96 --disable-cuda-graph"
+    }
     lm.kwargs = {}
 
     with mock.patch.dict("sys.modules", {"sglang": mock.Mock(), "sglang.utils": mock.Mock()}):
-        LocalProvider.launch(lm, launch_kwargs={})
+        LocalProvider.launch(lm)
 
         assert mock_popen.called
         call_args = mock_popen.call_args
@@ -32,6 +34,13 @@ def test_command_with_spaces_in_path(mock_wait, mock_port, mock_popen, mock_thre
         assert "--model-path" in command
         model_index = command.index("--model-path")
         assert command[model_index + 1] == "/path/to/my models/llama"
+        
+        # Check for extra args
+        assert "--cuda-graph-max-bs" in command
+        bs_index = command.index("--cuda-graph-max-bs")
+        assert command[bs_index + 1] == "96"
+        
+        assert "--disable-cuda-graph" in command
 
 
 @patch("dspy.clients.lm_local.threading.Thread")
@@ -95,3 +104,42 @@ def test_command_is_list_not_string(mock_wait, mock_port, mock_popen, mock_threa
         assert "--model-path" in command
         assert "--port" in command
         assert "--host" in command
+
+
+@patch("dspy.clients.lm_local.threading.Thread")
+@patch("dspy.clients.lm_local.subprocess.Popen")
+@patch("dspy.clients.lm_local.get_free_port")
+@patch("dspy.clients.lm_local.wait_for_server")
+def test_launch_with_extra_args(mock_wait, mock_port, mock_popen, mock_thread): 
+    mock_port.return_value = 8000
+    mock_process = mock.Mock()
+    mock_process.pid = 12345
+    mock_process.stdout.readline.return_value = ""
+    mock_process.poll.return_value = 0
+    mock_popen.return_value = mock_process
+
+    lm = mock.Mock(spec=[])
+    lm.model = "meta-llama/Llama-2-7b"
+    lm.launch_kwargs = {
+        "extra_args": "--cuda-graph-max-bs 96 --disable-cuda-graph"
+    }
+    lm.kwargs = {}
+
+    with mock.patch.dict("sys.modules", {"sglang": mock.Mock(), "sglang.utils": mock.Mock()}):
+        LocalProvider.launch(lm)
+
+        assert mock_popen.called
+        call_args = mock_popen.call_args
+        command = call_args[0][0]
+
+        assert isinstance(command, list)
+        assert "--model-path" in command
+        model_index = command.index("--model-path")
+        assert command[model_index + 1] == "meta-llama/Llama-2-7b"
+        
+        # Check for extra args
+        assert "--cuda-graph-max-bs" in command
+        bs_index = command.index("--cuda-graph-max-bs")
+        assert command[bs_index + 1] == "96"
+        
+        assert "--disable-cuda-graph" in command

--- a/tests/clients/test_lm_local.py
+++ b/tests/clients/test_lm_local.py
@@ -35,7 +35,6 @@ def test_command_with_spaces_in_path(mock_wait, mock_port, mock_popen, mock_thre
         model_index = command.index("--model-path")
         assert command[model_index + 1] == "/path/to/my models/llama"
         
-        # Check for extra args
         assert "--cuda-graph-max-bs" in command
         bs_index = command.index("--cuda-graph-max-bs")
         assert command[bs_index + 1] == "96"
@@ -143,3 +142,4 @@ def test_launch_with_extra_args(mock_wait, mock_port, mock_popen, mock_thread):
         assert command[bs_index + 1] == "96"
         
         assert "--disable-cuda-graph" in command
+    

--- a/tests/clients/test_lm_local.py
+++ b/tests/clients/test_lm_local.py
@@ -19,7 +19,7 @@ def test_command_with_spaces_in_path(mock_wait, mock_port, mock_popen, mock_thre
     lm = mock.Mock(spec=[])
     lm.model = "/path/to/my models/llama"
     lm.launch_kwargs = {
-        "extra_args": "--cuda-graph-max-bs 96 --disable-cuda-graph"
+        "extra_args": ["--cuda-graph-max-bs", "96", "--disable-cuda-graph"]
     }
     lm.kwargs = {}
 
@@ -120,26 +120,26 @@ def test_launch_with_extra_args(mock_wait, mock_port, mock_popen, mock_thread):
     lm = mock.Mock(spec=[])
     lm.model = "meta-llama/Llama-2-7b"
     lm.launch_kwargs = {
-        "extra_args": "--cuda-graph-max-bs 96 --disable-cuda-graph"
+        "extra_args": ["--cuda-graph-max-bs", "96", "--disable-cuda-graph"]
     }
     lm.kwargs = {}
 
     with mock.patch.dict("sys.modules", {"sglang": mock.Mock(), "sglang.utils": mock.Mock()}):
         LocalProvider.launch(lm)
 
-        assert mock_popen.called
-        call_args = mock_popen.call_args
-        command = call_args[0][0]
+    assert mock_popen.called
+    call_args = mock_popen.call_args
+    command = call_args[0][0]
 
-        assert isinstance(command, list)
-        assert "--model-path" in command
-        model_index = command.index("--model-path")
-        assert command[model_index + 1] == "meta-llama/Llama-2-7b"
-        
-        # Check for extra args
-        assert "--cuda-graph-max-bs" in command
-        bs_index = command.index("--cuda-graph-max-bs")
-        assert command[bs_index + 1] == "96"
-        
-        assert "--disable-cuda-graph" in command
+    assert isinstance(command, list)
+    assert "--model-path" in command
+    model_index = command.index("--model-path")
+    assert command[model_index + 1] == "meta-llama/Llama-2-7b"
+    
+    # Check for extra args
+    assert "--cuda-graph-max-bs" in command
+    bs_index = command.index("--cuda-graph-max-bs")
+    assert command[bs_index + 1] == "96"
+    
+    assert "--disable-cuda-graph" in command
     


### PR DESCRIPTION
closes #10 

Added patch mentioned in issue which is: 

```
if extra_args := launch_kwargs.get("extra_args"):
    if not isinstance(extra_args, list):
        raise ValueError("extra_args must be a list")
    command.extend(extra_args)
```

which allows passing extra_args during launch of a local model.

Also, tested these and added an unit test for checking `extra_args`