### PR TITLE
Add LLMLingua Prompt Compressor in DSPy

### DIFF
--- a/docs/docs/api/primitives/PromptCompressor.md
+++ b/docs/docs/api/primitives/PromptCompressor.md
@@ -1,74 +1,19 @@
-# PromptCompressor
+# dspy.PromptCompressor
 
-The `PromptCompressor` module is intergrated in DSPy to significantly reduce token usage while using any Large Language Models and thereby reducing latency by locally accelerating context compression safely.
-
-It utilizes techniques from [Microsoft's LLMLingua](https://github.com/microsoft/LLMLingua) project mainly `llmlingua` and `llmlingua-2`. This primitive algorithmically shrinks large unorganized blocks of text while maintaining key entities, facts, and the core objectives defined by your signatures.
-
-
-### Basic Usage
-
-You can initialize a global default compressor and attach it via `dspy.settings.configure()`. 
-
-Whenever a `Predict` module runs, any fields explicitly marked with `compression=True` in your `dspy.Signature` will be intercepted and scaled down.
-
-```python
-import dspy
-
-# 1. Define your strict signature, explicitly marking long fields for compression
-class CheckCitationFaithfulness(dspy.Signature):
-    """Verify that the text is based on the provided context."""
-
-    context: str = dspy.InputField(desc="facts here are assumed to be true", compression=True)
-    text: str = dspy.InputField(compression=False)
-    faithfulness: bool = dspy.OutputField()
-    evidence: list[str] = dspy.OutputField(desc="List of exact quotes from the text supporting evidence for claims")
-
-
-
-def main():
-
-    # 2. Setup your PromptCompressor
-    compressor = dspy.PromptCompressor(
-        model_name="microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank",
-        dynamic_context_compression_ratio=0.55,           # desired compressed size as fraction of original tokens
-        preserve_fields=["username, history"],        # list of regex/keys to preserve fully (e.g., user names)
-        target_token=None,      # hard limit to compressed result if desired
-        device="cpu",                # or "cuda"
-        cache=True                   # cache results for identical inputs
-    )
-    # 3. Attach it globally alongside your LLM
-    lm = dspy.LM("ollama_chat/llama3.2:1b", api_base="http://localhost:11434", api_key=api_key)
-   
-    # 4. Configure settings and pass singature class defined to Predict module 
-    dspy.settings.configure(lm=lm, compressor=compressor)
-    evaluator = dspy.Predict(CheckCitationFaithfulness)
-
-    long_document_context = (
-        "Belgium, officially the Kingdom of Belgium, is a country in Northwestern Europe. "
-        "The country is bordered by the Netherlands to the north, Germany to the east, "
-        "Luxembourg to the southeast, France to the southwest, and the North Sea to the "
-        "northwest. It covers an area of 30,689 square kilometers and has a population "
-        "of more than 11.5 million. The capital and largest city is Brussels."
-    )
-    # call evalautor to get results
-    result = evaluator(
-        context=long_document_context,
-        text="Belgium's capital is Brussels and it neighbors the Netherlands."
-    )
-
-    print(result.faithfulness) # True
-    print(result.evidence)
-    # ["Belgium's capital is Brussels and it neighbors the Netherlands.", 'The country covers an area of 30,689 square kilometers', 'Belgium has a population of more than 11.5 million']
-
-    print(result.compression_metadata)
-    # {
-    #     'total_original_tokens': 82, 
-    #     'total_compressed_tokens': 37, 
-    #     'ratio': 0.45121951219512196, 
-    #     'model': 'microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank'
-    # }
-
-if __name__ == "__main__":
-    main()
-
-```
+<!-- START_API_REF -->
+::: dspy.PromptCompressor
+    handler: python
+    options:
+        members:
+            - __init__
+            - __call__
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+        inherited_members: true
+:::
+<!-- END_API_REF -->

--- a/docs/docs/api/primitives/PromptCompressor.md
+++ b/docs/docs/api/primitives/PromptCompressor.md
@@ -1,0 +1,74 @@
+# PromptCompressor
+
+The `PromptCompressor` module is intergrated in DSPy to significantly reduce token usage while using any Large Language Models and thereby reducing latency by locally accelerating context compression safely.
+
+It utilizes techniques from [Microsoft's LLMLingua](https://github.com/microsoft/LLMLingua) project mainly `llmlingua` and `llmlingua-2`. This primitive algorithmically shrinks large unorganized blocks of text while maintaining key entities, facts, and the core objectives defined by your signatures.
+
+
+### Basic Usage
+
+You can initialize a global default compressor and attach it via `dspy.settings.configure()`. 
+
+Whenever a `Predict` module runs, any fields explicitly marked with `compression=True` in your `dspy.Signature` will be intercepted and scaled down.
+
+```python
+import dspy
+
+# 1. Define your strict signature, explicitly marking long fields for compression
+class CheckCitationFaithfulness(dspy.Signature):
+    """Verify that the text is based on the provided context."""
+
+    context: str = dspy.InputField(desc="facts here are assumed to be true", compression=True)
+    text: str = dspy.InputField(compression=False)
+    faithfulness: bool = dspy.OutputField()
+    evidence: list[str] = dspy.OutputField(desc="List of exact quotes from the text supporting evidence for claims")
+
+
+
+def main():
+
+    # 2. Setup your PromptCompressor
+    compressor = dspy.PromptCompressor(
+        model_name="microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank",
+        dynamic_context_compression_ratio=0.55,           # desired compressed size as fraction of original tokens
+        preserve_fields=["username, history"],        # list of regex/keys to preserve fully (e.g., user names)
+        target_token=None,      # hard limit to compressed result if desired
+        device="cpu",                # or "cuda"
+        cache=True                   # cache results for identical inputs
+    )
+    # 3. Attach it globally alongside your LLM
+    lm = dspy.LM("ollama_chat/llama3.2:1b", api_base="http://localhost:11434", api_key=api_key)
+   
+    # 4. Configure settings and pass singature class defined to Predict module 
+    dspy.settings.configure(lm=lm, compressor=compressor)
+    evaluator = dspy.Predict(CheckCitationFaithfulness)
+
+    long_document_context = (
+        "Belgium, officially the Kingdom of Belgium, is a country in Northwestern Europe. "
+        "The country is bordered by the Netherlands to the north, Germany to the east, "
+        "Luxembourg to the southeast, France to the southwest, and the North Sea to the "
+        "northwest. It covers an area of 30,689 square kilometers and has a population "
+        "of more than 11.5 million. The capital and largest city is Brussels."
+    )
+    # call evalautor to get results
+    result = evaluator(
+        context=long_document_context,
+        text="Belgium's capital is Brussels and it neighbors the Netherlands."
+    )
+
+    print(result.faithfulness) # True
+    print(result.evidence)
+    # ["Belgium's capital is Brussels and it neighbors the Netherlands.", 'The country covers an area of 30,689 square kilometers', 'Belgium has a population of more than 11.5 million']
+
+    print(result.compression_metadata)
+    # {
+    #     'total_original_tokens': 82, 
+    #     'total_compressed_tokens': 37, 
+    #     'ratio': 0.45121951219512196, 
+    #     'model': 'microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank'
+    # }
+
+if __name__ == "__main__":
+    main()
+
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
             - History: api/primitives/History.md
             - Image: api/primitives/Image.md
             - Prediction: api/primitives/Prediction.md
+            - PromptCompressor: api/primitives/PromptCompressor.md
             - Tool: api/primitives/Tool.md
             - ToolCalls: api/primitives/ToolCalls.md
         - Signatures:

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -18,6 +18,7 @@ from dspy.dsp.utils.settings import settings
 from dspy.dsp.colbertv2 import ColBERTv2
 from dspy.clients import DSPY_CACHE
 from dspy.__metadata__ import __name__, __version__, __description__, __url__, __author__, __author_email__
+from dspy.primitives.compressor import PromptCompressor
 
 configure_dspy_loggers(__name__)
 

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -18,7 +18,6 @@ from dspy.dsp.utils.settings import settings
 from dspy.dsp.colbertv2 import ColBERTv2
 from dspy.clients import DSPY_CACHE
 from dspy.__metadata__ import __name__, __version__, __description__, __url__, __author__, __author_email__
-from dspy.primitives.compressor import PromptCompressor
 
 configure_dspy_loggers(__name__)
 

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG = dotdict(
     lm=None,
+    compressor=None,
     adapter=None,
     rm=None,
     branch_idx=0,

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -168,8 +168,10 @@ class Predict(Module, Parameter):
             )
         return lm, config, signature, demos, kwargs
 
-    def _forward_postprocess(self, completions, signature, **kwargs):
+    def _forward_postprocess(self, completions, signature, comp_meta=None, **kwargs):
         pred = Prediction.from_completions(completions, signature=signature)
+        if comp_meta is not None:
+            pred.compression_metadata=comp_meta
         if kwargs.pop("_trace", True) and settings.trace is not None and settings.max_trace_size > 0:
             trace = settings.trace
             if len(trace) >= settings.max_trace_size:
@@ -187,6 +189,10 @@ class Predict(Module, Parameter):
 
     def forward(self, **kwargs):
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
+        compressor = config.get("compressor") or settings.compressor
+        comp_meta = None
+        if compressor is not None:
+            kwargs, comp_meta = compressor(signature, kwargs)
 
         adapter = settings.adapter or ChatAdapter()
 
@@ -197,10 +203,14 @@ class Predict(Module, Parameter):
             with settings.context(send_stream=None):
                 completions = adapter(lm, lm_kwargs=config, signature=signature, demos=demos, inputs=kwargs)
 
-        return self._forward_postprocess(completions, signature, **kwargs)
+        return self._forward_postprocess(completions, signature, comp_meta=comp_meta, **kwargs)
 
     async def aforward(self, **kwargs):
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
+        compressor = config.get("compressor") or settings.compressor
+        comp_meta = None
+        if compressor is not None:
+            kwargs, comp_meta = compressor(signature, kwargs)
 
         adapter = settings.adapter or ChatAdapter()
         if self._should_stream():
@@ -210,7 +220,7 @@ class Predict(Module, Parameter):
             with settings.context(send_stream=None):
                 completions = await adapter.acall(lm, lm_kwargs=config, signature=signature, demos=demos, inputs=kwargs)
 
-        return self._forward_postprocess(completions, signature, **kwargs)
+        return self._forward_postprocess(completions, signature, comp_meta=comp_meta, **kwargs)
 
     def update_config(self, **kwargs):
         self.config = {**self.config, **kwargs}

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -168,10 +168,8 @@ class Predict(Module, Parameter):
             )
         return lm, config, signature, demos, kwargs
 
-    def _forward_postprocess(self, completions, signature, comp_meta=None, **kwargs):
+    def _forward_postprocess(self, completions, signature, **kwargs):
         pred = Prediction.from_completions(completions, signature=signature)
-        if comp_meta is not None:
-            pred.compression_metadata=comp_meta
         if kwargs.pop("_trace", True) and settings.trace is not None and settings.max_trace_size > 0:
             trace = settings.trace
             if len(trace) >= settings.max_trace_size:
@@ -203,7 +201,10 @@ class Predict(Module, Parameter):
             with settings.context(send_stream=None):
                 completions = adapter(lm, lm_kwargs=config, signature=signature, demos=demos, inputs=kwargs)
 
-        return self._forward_postprocess(completions, signature, comp_meta=comp_meta, **kwargs)
+        pred = self._forward_postprocess(completions, signature, **kwargs)
+        if comp_meta is not None:
+            pred.compression_metadata=comp_meta
+        return pred
 
     async def aforward(self, **kwargs):
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
@@ -220,7 +221,10 @@ class Predict(Module, Parameter):
             with settings.context(send_stream=None):
                 completions = await adapter.acall(lm, lm_kwargs=config, signature=signature, demos=demos, inputs=kwargs)
 
-        return self._forward_postprocess(completions, signature, comp_meta=comp_meta, **kwargs)
+        pred = self._forward_postprocess(completions, signature, **kwargs)
+        if comp_meta is not None:
+            pred.compression_metadata=comp_meta
+        return pred
 
     def update_config(self, **kwargs):
         self.config = {**self.config, **kwargs}

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -4,6 +4,7 @@ from dspy.primitives.example import Example
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Completions, Prediction
 from dspy.primitives.python_interpreter import PythonInterpreter
+from dspy.primitives.compressor import PromptCompressor
 
 __all__ = [
     "BaseModule",
@@ -15,4 +16,5 @@ __all__ = [
     "Module",
     "Prediction",
     "PythonInterpreter",
+    "PromptCompressor"
 ]

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -1,10 +1,10 @@
 from dspy.primitives.base_module import BaseModule
 from dspy.primitives.code_interpreter import CodeInterpreter, CodeInterpreterError, FinalOutput
+from dspy.primitives.compressor import PromptCompressor
 from dspy.primitives.example import Example
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Completions, Prediction
 from dspy.primitives.python_interpreter import PythonInterpreter
-from dspy.primitives.compressor import PromptCompressor
 
 __all__ = [
     "BaseModule",

--- a/dspy/primitives/compressor.py
+++ b/dspy/primitives/compressor.py
@@ -1,0 +1,108 @@
+import logging
+import torch
+from typing import Any, Dict, List, Optional, Tuple
+
+from dspy.signatures.signature import Signature
+
+try:
+    from llmlingua import PromptCompressor as ExternalCompressor
+except ImportError:
+    ExternalCompressor = None
+
+logger = logging.getLogger(__name__)
+
+class PromptCompressor:
+    "PromptCompressor class for compressing prompts locally while preserving key information."
+
+    def __init__(self, 
+        model_name: str,
+        dynamic_context_compression_ratio: float = 0.55,
+        target_token: Optional[int] = None,
+        preserve_fields: Optional[List[str]] = None,
+        device : Optional[str] = "cuda" if torch.cuda.is_available() else "cpu", 
+        cache: bool = True,
+        ) -> None:
+
+        self.model_name = model_name
+        self.dynamic_context_compression_ratio = dynamic_context_compression_ratio
+        self.target_token = target_token
+        self.preserve_fields = preserve_fields
+        self.device = device   
+        self.cache = cache
+        self.is_v2 = True if "lingua-2" in self.model_name else False
+
+        self._compressor = ExternalCompressor(
+            model_name=self.model_name,
+            device_map=self.device
+        )
+
+    def __call__(
+        self,
+        signature: type[Signature],
+        kwargs: Dict[str, Any],
+    )-> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        compress input fields based on signature information.
+
+        Args:
+            signature: The DSPy signature descirbing required task and fields
+            kwargs: The raw keyword arguments
+        
+        Returns:
+            A tuple containing:
+                - The modified dictionary of keyword arguments where targeted fields have been compressed.
+                - A metadata dictionary carrying token reduction statistics.
+
+        """
+
+        compressed_kwargs = kwargs.copy()
+        total_original_tokens = 0
+        total_compressed_tokens = 0
+        fields_compressed = 0
+
+        for field_name, value in kwargs.items():
+            if field_name not in signature.input_fields:
+                continue
+            
+            field_info = signature.input_fields[field_name]
+            should_compress = field_info.json_schema_extra.get("compression", True)
+
+            if not should_compress or field_name in self.preserve_fields:
+                continue
+            
+            if not isinstance(value, str) or not value.strip():
+                continue
+            
+            try:
+                if self.is_v2: 
+                    result = self._compressor.compress_prompt(
+                        value
+                    )
+
+                else: 
+                    result = self._compressor.compress_prompt(
+                        prompt=[value],
+                        instruction="", 
+                        question="", 
+                        target_token=self.target_token,
+                        dynamic_context_compression_ratio=self.dynamic_context_compression_ratio
+                    )
+                compressed_kwargs[field_name] = result.get("compressed_prompt", value)
+                total_original_tokens += result.get("origin_tokens", 0)
+                total_compressed_tokens += result.get("compressed_tokens", 0)
+                fields_compressed += 1
+
+            except Exception as e:
+                logger.warning(f"Failed to compress field {field_name}: {e}")
+            
+
+        ratio = total_compressed_tokens / max(total_original_tokens, 1) if fields_compressed > 0 else 1
+        compression_metadata = {
+            "total_original_tokens": total_original_tokens,
+            "total_compressed_tokens": total_compressed_tokens,
+            "ratio": ratio,
+            "model": self.model_name
+        }
+
+        return compressed_kwargs, compression_metadata
+    

--- a/dspy/primitives/compressor.py
+++ b/dspy/primitives/compressor.py
@@ -1,6 +1,5 @@
 import logging
-import torch
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from dspy.signatures.signature import Signature
 
@@ -12,25 +11,53 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 class PromptCompressor:
-    "PromptCompressor class for compressing prompts locally using LLMlingua while preserving key information."
+    """
+    A module to systematically compress prompts to recuce token consumption and latency while preserving key information.
+    """
 
     def __init__(self, 
         model_name: str,
-        dynamic_context_compression_ratio: float = 0.55,
-        target_token: Optional[int] = None,
+        dynamic_context_compression_ratio: float = 0.0,
+        target_token: Optional[float] = None,
         preserve_fields: Optional[List[str]] = None,
-        device : Optional[str] = "cuda" if torch.cuda.is_available() else "cpu", 
+        device : Optional[str] = "cpu", 
         cache: bool = True,
         ) -> None:
 
+        """
+        Initalized PromptCompressor Class.
+
+        Args:
+            model_name (str, optional): The name of the model to be loaded. Default is "NousResearch/Llama-2-7b-hf".
+            dynamic_context_compression_ratio (float): Ratio for dynamically adjusting context compression. Default is 0.0.
+            target_token (Optional[float]): The global maximum number of tokens to be achieved. Default is -1, indicating no
+                specific target. The actual number of tokens after compression should generally be less than the specified target_token,
+                but there can be fluctuations due to differences in tokenizers. If specified, compression will be based on the target_token as
+                the sole criterion, overriding the ``rate``. ``target_token``, is applicable only within the context-level
+                filter and the sentence-level filter. In the token-level filter, the rate for each segment overrides the global target token.
+                However, for segments where no specific rate is defined, the global rate calculated from global target token serves
+                as the default value. The final target token of the entire text is a composite result of multiple compression rates
+                applied across different sections.
+            preserve_fields (Optional[List[str]]): A specific list of field names corresponding to signature elements that should be  
+                bypassed during compression runs and left entirely unmodified. Defaults to "None".
+            device (str, optional): The device to load the model onto, supported "cuda", "cpu", "mps". Default is "cpu". 
+            cache:
+        """
+        
         if ExternalCompressor is None:
             raise ImportError("llmlingua is not installed. Please install it with `pip install llmlingua`.")
+
+        if device is None:
+            try:
+                import torch
+                self.device = "cuda" if torch.cuda.is_available() else "cpu"
+            except ImportError:
+                self.device = "cpu"
 
         self.model_name = model_name
         self.dynamic_context_compression_ratio = dynamic_context_compression_ratio
         self.target_token = target_token
         self.preserve_fields = preserve_fields
-        self.device = device   
         self.cache = cache
         self.is_v2 = True if "lingua-2" in self.model_name else False
 
@@ -43,8 +70,8 @@ class PromptCompressor:
     def __call__(
         self,
         signature: type[Signature],
-        kwargs: Dict[str, Any],
-    )-> Tuple[Dict[str, Any], Dict[str, Any]]:
+        kwargs: dict[str, Any],
+    )-> Tuple[dict[str, Any], dict[str, Any]]:
         """
         compress input fields based on signature information.
 
@@ -84,11 +111,10 @@ class PromptCompressor:
                     )
 
                 else: 
+                    lingua_target = self.target_token if self.target_token is not None else -1.0
                     result = self._compressor.compress_prompt(
                         prompt=[value],
-                        instruction="", 
-                        question="", 
-                        target_token=self.target_token,
+                        target_token=lingua_target,
                         dynamic_context_compression_ratio=self.dynamic_context_compression_ratio
                     )
                 compressed_kwargs[field_name] = result.get("compressed_prompt", value)

--- a/dspy/primitives/compressor.py
+++ b/dspy/primitives/compressor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 from dspy.signatures.signature import Signature
 
@@ -10,20 +10,21 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
 class PromptCompressor:
     """
     A module to systematically compress prompts to recuce token consumption and latency while preserving key information.
     """
 
-    def __init__(self, 
+    def __init__(
+        self,
         model_name: str,
         dynamic_context_compression_ratio: float = 0.0,
-        target_token: Optional[float] = None,
-        preserve_fields: Optional[List[str]] = None,
-        device : Optional[str] = "cpu", 
+        target_token: float | None = None,
+        preserve_fields: list[str] | None = None,
+        device: str | None = "cpu",
         cache: bool = True,
-        ) -> None:
-
+    ) -> None:
         """
         Initalized PromptCompressor Class.
 
@@ -38,47 +39,48 @@ class PromptCompressor:
                 However, for segments where no specific rate is defined, the global rate calculated from global target token serves
                 as the default value. The final target token of the entire text is a composite result of multiple compression rates
                 applied across different sections.
-            preserve_fields (Optional[List[str]]): A specific list of field names corresponding to signature elements that should be  
+            preserve_fields (Optional[List[str]]): A specific list of field names corresponding to signature elements that should be
                 bypassed during compression runs and left entirely unmodified. Defaults to "None".
-            device (str, optional): The device to load the model onto, supported "cuda", "cpu", "mps". Default is "cpu". 
+            device (str, optional): The device to load the model onto, supported "cuda", "cpu", "mps". Default is "cpu".
             cache:
         """
-        
+
         if ExternalCompressor is None:
             raise ImportError("llmlingua is not installed. Please install it with `pip install llmlingua`.")
 
         if device is None:
             try:
                 import torch
+
                 self.device = "cuda" if torch.cuda.is_available() else "cpu"
             except ImportError:
                 self.device = "cpu"
+        else:
+            self.device = device
 
         self.model_name = model_name
         self.dynamic_context_compression_ratio = dynamic_context_compression_ratio
         self.target_token = target_token
-        self.preserve_fields = preserve_fields
+        self.preserve_fields = preserve_fields or []
         self.cache = cache
         self.is_v2 = True if "lingua-2" in self.model_name else False
 
         self._compressor = ExternalCompressor(
-            model_name=self.model_name,
-            use_llmlingua2=self.is_v2,
-            device_map=self.device
+            model_name=self.model_name, use_llmlingua2=self.is_v2, device_map=self.device
         )
 
     def __call__(
         self,
         signature: type[Signature],
         kwargs: dict[str, Any],
-    )-> Tuple[dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """
         compress input fields based on signature information.
 
         Args:
             signature: The DSPy signature descirbing required task and fields
             kwargs: The raw keyword arguments
-        
+
         Returns:
             A tuple containing:
                 - The modified dictionary of keyword arguments where targeted fields have been compressed.
@@ -94,28 +96,26 @@ class PromptCompressor:
         for field_name, value in kwargs.items():
             if field_name not in signature.input_fields:
                 continue
-            
+
             field_info = signature.input_fields[field_name]
             should_compress = field_info.json_schema_extra.get("compression", True)
 
             if not should_compress or field_name in self.preserve_fields:
                 continue
-            
+
             if not isinstance(value, str) or not value.strip():
                 continue
-            
-            try:
-                if self.is_v2: 
-                    result = self._compressor.compress_prompt(
-                        value
-                    )
 
-                else: 
+            try:
+                if self.is_v2:
+                    result = self._compressor.compress_prompt(value)
+
+                else:
                     lingua_target = self.target_token if self.target_token is not None else -1.0
                     result = self._compressor.compress_prompt(
                         prompt=[value],
                         target_token=lingua_target,
-                        dynamic_context_compression_ratio=self.dynamic_context_compression_ratio
+                        dynamic_context_compression_ratio=self.dynamic_context_compression_ratio,
                     )
                 compressed_kwargs[field_name] = result.get("compressed_prompt", value)
                 total_original_tokens += result.get("origin_tokens", 0)
@@ -124,15 +124,13 @@ class PromptCompressor:
 
             except Exception as e:
                 logger.warning(f"Failed to compress field {field_name}: {e}")
-            
 
         ratio = total_compressed_tokens / max(total_original_tokens, 1) if fields_compressed > 0 else 1
         compression_metadata = {
             "total_original_tokens": total_original_tokens,
             "total_compressed_tokens": total_compressed_tokens,
             "ratio": ratio,
-            "model": self.model_name
+            "model": self.model_name,
         }
 
         return compressed_kwargs, compression_metadata
-    

--- a/dspy/primitives/compressor.py
+++ b/dspy/primitives/compressor.py
@@ -12,7 +12,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 class PromptCompressor:
-    "PromptCompressor class for compressing prompts locally while preserving key information."
+    "PromptCompressor class for compressing prompts locally using LLMlingua while preserving key information."
 
     def __init__(self, 
         model_name: str,
@@ -22,6 +22,9 @@ class PromptCompressor:
         device : Optional[str] = "cuda" if torch.cuda.is_available() else "cpu", 
         cache: bool = True,
         ) -> None:
+
+        if ExternalCompressor is None:
+            raise ImportError("llmlingua is not installed. Please install it with `pip install llmlingua`.")
 
         self.model_name = model_name
         self.dynamic_context_compression_ratio = dynamic_context_compression_ratio
@@ -33,6 +36,7 @@ class PromptCompressor:
 
         self._compressor = ExternalCompressor(
             model_name=self.model_name,
+            use_llmlingua2=self.is_v2,
             device_map=self.device
         )
 

--- a/dspy/signatures/field.py
+++ b/dspy/signatures/field.py
@@ -3,7 +3,7 @@ import pydantic
 # The following arguments can be used in DSPy InputField and OutputField in addition
 # to the standard pydantic.Field arguments. We just hope pydanitc doesn't add these,
 # as it would give a name clash.
-DSPY_FIELD_ARG_NAMES = ["desc", "prefix", "format", "parser", "__dspy_field_type"]
+DSPY_FIELD_ARG_NAMES = ["desc", "prefix", "format", "parser", "__dspy_field_type", "compression"]
 
 PYDANTIC_CONSTRAINT_MAP = {
     "gt": "greater than: ",

--- a/tests/primitives/test_compressor.py
+++ b/tests/primitives/test_compressor.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+import dspy
+from dspy.primitives.compressor import PromptCompressor
+
+
+class DummySignature(dspy.Signature):
+    context: str = dspy.InputField(compression=True)
+    query: str = dspy.InputField(compression=False)
+    answer: str = dspy.OutputField()
+
+
+@patch("dspy.primitives.compressor.ExternalCompressor")
+def test_compressor_initialization_and_v2_flag(mock_compressor):
+    """Test to check version flags passed to LLMLingua."""
+    PromptCompressor(
+        model_name="microsoft/llmlingua-2-xlm-roberta-large-meetingbank",
+    )
+    mock_compressor.assert_called_once()
+    assert mock_compressor.call_args[1]["use_llmlingua2"] is True
+
+
+@patch("dspy.primitives.compressor.ExternalCompressor")
+def test_selective_compression_and_metadata(mock_compressor):
+    """Test that ONLY compression=True fields are modified, and math is correct."""
+    mock_instance = MagicMock()
+    mock_instance.compress_prompt.return_value = {
+        "compressed_prompt": "compact text",
+        "origin_tokens": 10,
+        "compressed_tokens": 2,
+    }
+    mock_compressor.return_value = mock_instance
+
+    compressor = PromptCompressor(model_name="standard")
+    kwargs = {"context": "very long text", "query": "short query"}
+
+    compressed_kwargs, meta = compressor(DummySignature, kwargs)
+    # Assert routing logic
+    assert compressed_kwargs["context"] == "compact text"  # Modified!
+    assert compressed_kwargs["query"] == "short query"  # Untouched!
+
+    # Assert metric math
+    assert meta["total_original_tokens"] == 10
+    assert meta["total_compressed_tokens"] == 2
+    assert meta["ratio"] == 0.2
+
+
+@patch("dspy.primitives.compressor.ExternalCompressor")
+def test_preserve_fields_override(mock_compressor):
+    """Test that fields strictly inside preserve_fields bypass compression entirely."""
+    mock_instance = MagicMock()
+    mock_compressor.return_value = mock_instance
+
+    compressor = PromptCompressor(model_name="std", preserve_fields=["context"])
+    kwargs = {"context": "very long text", "query": "short query"}
+
+    compressed_kwargs, meta = compressor(DummySignature, kwargs)
+
+    # Assert the LLMlingua function was NEVER even triggered
+    mock_instance.compress_prompt.assert_not_called()
+    assert compressed_kwargs["context"] == "very long text"


### PR DESCRIPTION
Related to issue  #13
 This PR adds Prompt Compressor using the LLMLingua library in DSPy
It introduces new PromptCompressor class which uses the functionality from LLMLingua

Below is the code snipper that I have used to check whether working of code: 

```
import dspy

class CheckCitationFaithfulness(dspy.Signature):
    """Verify that the text is based on the provided context."""

    context: str = dspy.InputField(desc="facts here are assumed to be true", compression=True)
    text: str = dspy.InputField(compression=False)
    faithfulness: bool = dspy.OutputField()
    evidence: list[str] = dspy.OutputField(desc="List of exact quotes from the text supporting evidence for claims")



def main():

    # create compressor 
    compressor = dspy.PromptCompressor(
        model_name="microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank",
        dynamic_context_compression_ratio=0.55,           # desired compressed size as fraction of original tokens
        preserve_fields=["username, history"],        # list of regex/keys to preserve fully (e.g., user names)
        target_token=None,      # hard limit to compressed result if desired
        device="cpu",                # or "cuda"
        cache=True                   # cache results for identical inputs
    )
    lm = dspy.LM("ollama_chat/llama3.2:1b", api_base="http://localhost:11434", api_key=api_key)
    dspy.settings.configure(lm=lm, compressor=compressor)
    evaluator = dspy.Predict(CheckCitationFaithfulness)
    long_document_context = (
        "Belgium, officially the Kingdom of Belgium, is a country in Northwestern Europe. "
        "The country is bordered by the Netherlands to the north, Germany to the east, "
        "Luxembourg to the southeast, France to the southwest, and the North Sea to the "
        "northwest. It covers an area of 30,689 square kilometers and has a population "
        "of more than 11.5 million. The capital and largest city is Brussels."
    )
    
    # 5. Execute the prompt!
    result = evaluator(
        context=long_document_context,
        text="Belgium's capital is Brussels and it neighbors the Netherlands."
    )

    print(result.faithfulness)
    print(result.evidence)
    print(result.compression_metadata)

if __name__ == "__main__":
    main()
```


Its output is: 
```
True
["Belgium's capital is Brussels and it neighbors the Netherlands.", 'The Kingdom of Belgium has its capital in Brussels.']
{'total_original_tokens': 82, 'total_compressed_tokens': 37, 'ratio': 0.45121951219512196, 'model': 'microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank'}
```

I have also updated docs, and checked them